### PR TITLE
Generic improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This script comes without any warranty whatsoever. Do not use it in production. 
 ## Features
 
 * It is specifically built for getting Revolut transactions into SnelStart. 
-* Parses the Revolut CSV file and extracts: timestamp, counterparty name, transaction description, transaction amount, fee amount, balance after transaction, counterparty IBAN.
+* Parses the Revolut CSV file and extracts: timestamp, transaction type, transaction description, transaction reference, transaction amount, fee amount, balance after transaction, counterparty IBAN.
 * This information is converted into a valid MT940 file.
 * Revolut charges fees for transactions. These are included in the transaction (as Revolut sees it). This could cause problems when importing into bookkeeping software as the amounts do not match up. This script will not include fees in transactions but insert "fake" transactions for each deducted fee. You will see those transactions separately in your bookkeeping software but in Revolut they are included in the transaction.
 

--- a/main.py
+++ b/main.py
@@ -29,9 +29,9 @@ def main():
     args = parser.parse_args()
 
     reader = RevolutCsvReader(args.input_file)
+    transactions = reader.get_all_transactions()
 
-    with Mt940Writer(args.output_file, args.account_iban) as writer:
-        transactions = reader.get_all_transactions()
+    with Mt940Writer(args.output_file, args.account_iban, transactions[0].datetime.strftime('%Y-%m')) as writer:
         for transaction in transactions:
             writer.write_transaction(transaction)
 

--- a/mt940.py
+++ b/mt940.py
@@ -63,7 +63,7 @@ class Mt940Writer:
         self.file.writelines([
             Mt940.make_20(BANK_NAME, month),
             Mt940.make_25(self.account_iban, CURRENCY),
-            Mt940.make_28(DEFAULT_SEQUENCE_NO)
+            Mt940.make_28c(DEFAULT_SEQUENCE_NO)
         ])
 
 
@@ -95,7 +95,7 @@ FORMAT_20 = ':20:' + TAG_940 + '{bank}-{month}\n'
 FORMAT_25 = ':25:{iban} {currency}\n'
 
 # sequence no
-FORMAT_28 = ':28:{seqno}\n'
+FORMAT_28C = ':28C:{seqno}\n'
 
 # opening balance
 FORMAT_60F = ':60F:{sign}{date}{currency}{amount}\n'
@@ -132,8 +132,8 @@ class Mt940:
             currency=currency)
 
     @staticmethod
-    def make_28(seqno):
-        return FORMAT_28.format(
+    def make_28c(seqno):
+        return FORMAT_28C.format(
             seqno=Mt940.pad_5(seqno))
 
     @staticmethod

--- a/mt940.py
+++ b/mt940.py
@@ -86,10 +86,7 @@ CURRENCY = 'EUR'
 TAG_940 = '940'
 
 # header
-FORMAT_HEADER = \
-    '{bic}\n' + \
-    TAG_940 + '\n' + \
-    '{bic}\n'
+FORMAT_HEADER = ':' + TAG_940 + ':\n'
 
 # transaction ref
 FORMAT_20 = ':20:{bank}\n'

--- a/mt940.py
+++ b/mt940.py
@@ -104,7 +104,7 @@ FORMAT_60F = ':60F:{sign}{date}{currency}{amount}\n'
 FORMAT_62F = ':62F:{sign}{date}{currency}{amount}\n'
 
 # transaction
-FORMAT_61 = ':61:{date}{date2}{amount}{magic}\n'
+FORMAT_61 = ':61:{date}{amount}{magic}\n'
 
 # transaction 2
 FORMAT_86 = ':86:/IBAN/{iban}/NAME/{name}/REMI/{description}\n'
@@ -156,7 +156,6 @@ class Mt940:
     def make_61(datetime, amount):
         return FORMAT_61.format(
             date=Mt940.date(datetime),
-            date2=Mt940.date(datetime, with_year=False),
             amount=Mt940.amount(amount),
             magic=MAGIC)
 

--- a/mt940.py
+++ b/mt940.py
@@ -8,11 +8,11 @@ DEFAULT_SEQUENCE_NO = 1
 
 class Mt940Writer:
 
-    def __init__(self, filename, account_iban):
+    def __init__(self, filename, account_iban, month):
         self.file = open(filename, 'w')
         self.account_iban = account_iban
 
-        self._write_header()
+        self._write_header(month)
         self._written_starting_balance = False
         self._written_ending_balance = False
 
@@ -57,11 +57,11 @@ class Mt940Writer:
             self.file.close()
 
 
-    def _write_header(self):
+    def _write_header(self, month):
         self.file.write(
             Mt940.make_header(BANK_BIC))
         self.file.writelines([
-            Mt940.make_20(BANK_NAME),
+            Mt940.make_20(BANK_NAME, month),
             Mt940.make_25(self.account_iban, CURRENCY),
             Mt940.make_28(DEFAULT_SEQUENCE_NO)
         ])
@@ -89,7 +89,7 @@ TAG_940 = '940'
 FORMAT_HEADER = ':' + TAG_940 + ':\n'
 
 # transaction ref
-FORMAT_20 = ':20:{bank}\n'
+FORMAT_20 = ':20:' + TAG_940 + '{bank}-{month}\n'
 
 # account id
 FORMAT_25 = ':25:{iban} {currency}\n'
@@ -120,9 +120,10 @@ class Mt940:
             bic=bic)
 
     @staticmethod
-    def make_20(bank):
+    def make_20(bank, month):
         return FORMAT_20.format(
-            bank=bank)
+            bank=bank,
+            month=month)
 
     @staticmethod
     def make_25(iban, currency):


### PR DESCRIPTION
Hi Gerwin, thanks for writing these Python scripts! I tried them out, but needed to change some things before Moneybird would recognize the generated MT940 files. Some of the improvements appear to be usable for users of SnelStart as well, which is why I opened this PR :slightly_smiling_face: 

For reference, I used:
- https://www.coenfin.nl/software/mt940-creator to generate a valid MT940 file that Moneybird _did_ recognize, so I could do some line-by-line debugging from there (Moneybird doesn't show any parsing error details, just that it failed).
- MT940 reference manuals like [this](https://www2.swift.com/knowledgecentre/publications/us9m_20210723/1.0?topic=mt940.htm) and [this](https://www.ingwb.com/binaries/content/assets/support-content/payments-and-reporting/insidebusiness-payments/ing-format-description-mt940-swift-mt940---ibp-v1.0.pdf).

The output of the scripts should™ be fully* compliant with the spec now, but I also added some changes that are more my preference, so feel free to request the removal of any of these commits from this PR. I have even more commits at https://github.com/mpsijm/revolut-to-mt940/tree/moneybird, but as the name suggests, these are really specific to how I use the MT940 to import into Moneybird :smile: 

*) The only thing is: it's still not compliant to the line limit of 65 characters, but neither SnelStart nor Moneybird complains about that, so let's ignore the line limit 😛 